### PR TITLE
reexport Data.Bifunctor

### DIFF
--- a/Prolude/Core.hs
+++ b/Prolude/Core.hs
@@ -7,6 +7,7 @@ module Prolude.Core
   , module Data.Monoid
     -- * Base re-exports
   , module Data.Bool
+  , module Data.Bifunctor
   , module Data.Either
   , module Data.Eq
   , module Data.Foldable
@@ -48,6 +49,7 @@ import Control.Applicative (Applicative(pure, (*>), (<*), (<*>)))
 import Control.Monad (Monad((>>), (>>=)))
 import Control.Monad.Fail (MonadFail(fail))
 import Data.Bool (Bool(False, True), not, otherwise, (&&), (||))
+import Data.Bifunctor (Bifunctor(bimap, first, second))
 import Data.Char (Char, chr, ord)
 import Data.Either (Either(Left, Right), either)
 import Data.Eq (Eq((/=), (==)))


### PR DESCRIPTION
motivation:
consider the following code:
```haskell
decodeFoo :: String -> Either Stirng Foo
decodeFoo = undefined

-- error message doesn't tell the full story
decodeBigFoo :: String -> Either String BigFoo
decodeBigFoo =
      BigFoo
  <$> decodeFoo
  <*> decodeFoo
  <*> decodeFoo

-- a little verbose
decodeBigFooBetter :: String -> Either String BigFoo
decodeBigFooBetter =
      BigFoo
  <$> either Left (Right . ("1: " <>)) decodeFoo
  <*> either Left (Right . ("2: " <>)) decodeFoo
  <*> either Left (Right . ("3: " <>)) decodeFoo

decodeBigFooBest :: String -> Either String BigFoo
decodeBigFooBest =
      BigFoo
  <$> first ("1: " <>) decodeFoo
  <*> first ("2: " <>) decodeFoo
  <*> first ("3: " <>) decodeFoo
```

i also just find `Bifunctor` to be useful generally. 